### PR TITLE
Removed integer keys when the cursor is returning a dictionary.

### DIFF
--- a/pytds/dbapi.py
+++ b/pytds/dbapi.py
@@ -299,9 +299,7 @@ class _Connection(object):
         cols = session.res_info.columns
         row = tuple(col.value for col in cols)
         if self.as_dict:
-            row_dict = dict(enumerate(cols))
-            row_dict.update(dict((col.column_name, col.value) for col in cols if col.column_name))
-            row = row_dict
+            row = dict((col.column_name, col.value) for col in cols if col.column_name)
         return row
 
     def _nextset(self, session):


### PR DESCRIPTION
This removes the integer keys that allow the returned row to emulate a list. To me it makes sense that a dictionary returned would not have the column offsets as keys and column names at the same time.

I'm not sure if this will break the django backend or not, as I've not used it. If so, feel free to close without merging.

Thanks for this awesome project, not having to depend upon FreeTDS is really nice.
