### PR TITLE
Fixing bug: AttributeError: type object 'Float' has no attribute 'from_s...

### DIFF
--- a/pytds/tds.py
+++ b/pytds/tds.py
@@ -1000,6 +1000,10 @@ class IntN(BaseType):
 class Real(BaseType):
     type = SYBREAL
 
+    @classmethod
+    def from_stream(cls, r):
+        return cls()
+
     def get_declaration(self):
         return 'REAL'
 
@@ -1016,6 +1020,10 @@ Real.instance = Real()
 
 class Float(BaseType):
     type = SYBFLT8
+
+    @classmethod
+    def from_stream(cls, r):
+        return cls()
 
     def get_declaration(self):
         return 'FLOAT'


### PR DESCRIPTION
...tream' of python-tds

I installed [django-sqlserver](https://bitbucket.org/cramm/django-sqlserver/overview) and pytds to work with a database in SQL Server 2005. When I ran the command `inspectdb` I got this:

```
  File "/home/diegueus9/dev/whatsup/local/lib/python2.7/site-packages/pytds/tds.py", line 3411, in find_result_or_done
    self.process_token(marker)
  File "/home/diegueus9/dev/whatsup/local/lib/python2.7/site-packages/pytds/tds.py", line 3345, in process_token
    return handler(self)
  File "/home/diegueus9/dev/whatsup/local/lib/python2.7/site-packages/pytds/tds.py", line 3458, in <lambda>
    TDS7_RESULT_TOKEN: lambda self: self.tds7_process_result(),
  File "/home/diegueus9/dev/whatsup/local/lib/python2.7/site-packages/pytds/tds.py", line 2440, in tds7_process_result
    self.get_type_info(curcol)
  File "/home/diegueus9/dev/whatsup/local/lib/python2.7/site-packages/pytds/tds.py", line 2407, in get_type_info
    curcol.type = self.get_type_factory(type_id).from_stream(r)
AttributeError: type object 'Float' has no attribute 'from_stream'
```
