### PR TITLE
pytds timeouts, fixed query timeout that was being ignored

### DIFF
--- a/pytds/dbapi.py
+++ b/pytds/dbapi.py
@@ -143,7 +143,6 @@ class _Connection(object):
         if not login.port:
             login.port = 1433
         connect_timeout = login.connect_timeout
-        #login.query_timeout = login.connect_timeout if login.connect_timeout else login.query_timeout
         for host in login.load_balancer.choose():
             try:
                 sock = socket.create_connection(


### PR DESCRIPTION
In the pytds/dbapi, _Connection class there are two timeouts in __init__, login_timeout and timeout.

login_timeout should be used to establish the socket connection whereas timeout is for query timeouts. 

the following line of existing code overwrites the query_timeout with the login_timeout before can be used. 

```
login.query_timeout = login.connect_timeout if login.connect_timeout else login.query_timeout
```

Also the line

```
sock.settimeout(login.query_timeout)
```

was being called before the initial socket connection overriding the connect_timeout (login_timeout). This should be called after the initial login is established for any subsequence calls.

Lastly, the timeout=0 default is incorrect forcing a timeout immediately. As per the python socket library documentation, None is used as opposed to 0 to block forever. Changed this value to None as default. 

To test using MSSQL, establish a connection and use the following SQL to test timeouts (this will timeout in the existing code). 

```
WAITFOR DELAY '00:01:05'
```
