### PR TITLE
namedtuple/recordtype rows corner-cases fixes, indexing support

### DIFF
--- a/pytds/dbapi.py
+++ b/pytds/dbapi.py
@@ -70,9 +70,20 @@ def recordtype_row_strategy(column_names):
     import recordtype # optional dependency
     # replace empty column names with placeholders
     column_names = [name if is_valid_identifier(name) else 'col%s_' % idx for idx, name in enumerate(column_names)]
-    row_class = recordtype.recordtype('Row', column_names)
+    recordtype_row_class = recordtype.recordtype('Row', column_names)
+
+    # custom extension class that supports indexing
+    class Row(recordtype_row_class):
+        def __getitem__(self, index):
+            if isinstance(index, slice):
+                return tuple(getattr(self, x) for x in self.__slots__[index])
+            return getattr(self, self.__slots__[index])
+
+        def __setitem__(self, index, value):
+            setattr(self, self.__slots__[index], value)
+            
     def row_factory(row):
-        return row_class(*row)
+        return Row(*row)
     return row_factory
 
 ######################


### PR DESCRIPTION
Fixed crash in namedtuple/recordtype rows happens when column name is not a valid python identifier or is a keyword

Added indexing support for recordtype-based rows

This pull request also contains old fix that allows passing None as server/database name. See another pull request for details.
