### PR TITLE
memory leak fixed, circular dependency between cursor <-> connection

### DIFF
--- a/pytds/__init__.py
+++ b/pytds/__init__.py
@@ -395,8 +395,7 @@ class Connection(object):
             raise
 
     def __del__(self):
-        if self._conn is not None:
-            self._conn.close()
+        self.close()
 
     def close(self):
         """ Close connection to an MS SQL Server.
@@ -407,6 +406,8 @@ class Connection(object):
         """
         if self._conn:
             self._conn.close()
+            self._active_cursor = None
+            self._main_cursor = None
             self._conn = None
         self._closed = True
 
@@ -445,8 +446,7 @@ class Cursor(six.Iterator):
         return self
 
     def __exit__(self, *args):
-        if self._conn is not None:
-            self.close()
+        self.close()
 
     def __iter__(self):
         """


### PR DESCRIPTION
Memory leak fixed, circular dependency between cursor <-> connection prevented both from being deleted, GC doesn't work for objects with **del**

Following trivial script shows the problem:

```
import pytds
import guppy

hpy = guppy.hpy()

def test():
    with pytds.connect(...) as connection:
        with connection.cursor() as cursor:
            cursor.execute('select count(*) from SomeTable')
            cursor.fetchall()

while True:
    for i in range(100):
        test()
    print hpy.heap()
```
