### PR TITLE
Fix for issue https://github.com/denisenkom/pytds/issues/38

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1450,8 +1450,6 @@ class DbapiTestSuite(dbapi20.DatabaseAPI20Test, DbTestCase):
 CREATE PROCEDURE add_one (@input int)
 AS
 BEGIN
-    select 'a' as a
-    select 'b' as b
     return @input+1
 END
 """,
@@ -1462,6 +1460,32 @@ END
             cur = con.cursor()
             self._retval_setup(cur)
             values = cur.callproc('add_one', (1,))
+            self.assertEqual(values[0], 1, 'input parameter should be left unchanged: %s' % (values[0],))
+
+            self.assertEqual(cur.description, None, "No resultset was expected.")
+            self.assertEqual(cur.return_value, 2, "Invalid return value: %s" % (cur.return_value,))
+
+        # This should create a sproc with a return value.
+    def _retval_select_setup(self, cur):
+        self._try_run2(
+            cur,
+            """IF OBJECT_ID(N'[dbo].[add_one_select]', N'P') IS NOT NULL DROP PROCEDURE [dbo].[add_one_select]""",
+            """
+CREATE PROCEDURE add_one_select (@input int)
+AS
+BEGIN
+    select 'a' as a
+    select 'b' as b
+    return @input+1
+END
+""",
+            )
+
+    def test_retval_select(self):
+        with self._connect() as con:
+            cur = con.cursor()
+            self._retval_select_setup(cur)
+            values = cur.callproc('add_one_select', (1,))
             self.assertEqual(values[0], 1, 'input parameter should be left unchanged: %s' % (values[0],))
 
             self.assertEqual(len(cur.description), 1, "Unexpected resultset.")


### PR DESCRIPTION
See https://github.com/denisenkom/pytds/issues/38 for details.

When return_value is accessed, tds discards all remaining rows.
It can lead to perception that procedure returned no rows.
    
This change ensures exception is raised if fetch is performed after return_value access.