### PR TITLE
Null as an argument fix

### DIFF
--- a/pytds/tds.py
+++ b/pytds/tds.py
@@ -10,6 +10,7 @@ from . import tz
 import re
 import uuid
 import six
+import types
 from six.moves import reduce
 from six.moves import xrange
 try:
@@ -3172,6 +3173,9 @@ class _TdsSession(object):
             value = value.value
         else:
             value_type = type(value)
+
+        if value_type is types.NoneType:
+            value_type = None
             
         if value is default:
             column.flags |= fDefaultValue

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1523,6 +1523,11 @@ END
             self.assertEqual(values[0], 1, 'input parameter should be unchanged')
             self.assertEqual(values[1], 2, 'output parameter should get new values')
 
+            values = cur.callproc('add_one_out', (None, output(value=1)))
+            self.assertEqual(len(values), 2, 'expected 2 parameters')
+            self.assertEqual(values[0], None, 'input parameter should be unchanged')
+            self.assertEqual(values[1], None, 'output parameter should get new values')
+
     def test_outparam_null_default(self):
         with self.assertRaises(ValueError):
             output(None, None)


### PR DESCRIPTION
Oops, recent changes in stored procedure output types broken passing null as a regular argument.
NoneType was passed as value_type instead of None.
Test and fix added.