### PR TITLE
Assigning select fix

### DIFF
--- a/pytds/tds.py
+++ b/pytds/tds.py
@@ -3798,8 +3798,13 @@ class _TdsSession(object):
             elif marker in (TDS_DONE_TOKEN, TDS_DONEPROC_TOKEN, TDS_DONEINPROC_TOKEN):
                 self.process_end(marker)
                 if self.done_flags & TDS_DONE_MORE_RESULTS:
-                    continue
-                return False
+                    if self.done_flags & TDS_DONE_COUNT:
+                        return True
+                    else:
+                        # skip results without rowcount
+                        continue
+                else:
+                    return False
             else:
                 self.process_token(marker)
 

--- a/pytds/tds.py
+++ b/pytds/tds.py
@@ -3797,8 +3797,7 @@ class _TdsSession(object):
                 return True
             elif marker in (TDS_DONE_TOKEN, TDS_DONEPROC_TOKEN, TDS_DONEINPROC_TOKEN):
                 self.process_end(marker)
-                if self.done_flags & TDS_DONE_MORE_RESULTS and not self.done_flags & TDS_DONE_COUNT:
-                    # skip results that don't event have rowcount
+                if self.done_flags & TDS_DONE_MORE_RESULTS:
                     continue
                 return False
             else:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1568,7 +1568,7 @@ select @var1 = 2
 select 'value'
 """)
             self.assertTrue(cur.description)
-            self.assertEqual(['value'], cur.fetchall())
+            self.assertEqual([(u'value',)], cur.fetchall())
             self.assertFalse(cur.nextset())
 
     # Don't need setoutputsize tests.

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1555,6 +1555,22 @@ END
             values = cur.callproc('testproc', (1, output(value=default, param_type=int), output(value=default, param_type=str)))
             self.assertEqual([1, 9, 'defstr1'], values)
 
+    def test_assigning_select(self):
+        # test that assigning select does not interfere with result sets
+        with self._connect() as con:
+            cur = con.cursor()
+            cur.execute("""
+declare @var1 int
+
+select @var1 = 1
+select @var1 = 2
+
+select 'value'
+""")
+            self.assertTrue(cur.description)
+            self.assertEqual(['value'], cur.fetchall())
+            self.assertFalse(cur.nextset())
+
     # Don't need setoutputsize tests.
     def test_setoutputsize(self):
         pass

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1567,6 +1567,26 @@ select @var1 = 2
 
 select 'value'
 """)
+            self.assertFalse(cur.description)
+            self.assertTrue(cur.nextset())
+            
+            self.assertFalse(cur.description)
+            self.assertTrue(cur.nextset())
+            
+            self.assertTrue(cur.description)
+            self.assertEqual([(u'value',)], cur.fetchall())
+            self.assertFalse(cur.nextset())
+
+            cur.execute("""
+set nocount on
+
+declare @var1 int
+
+select @var1 = 1
+select @var1 = 2
+
+select 'value'
+""")
             self.assertTrue(cur.description)
             self.assertEqual([(u'value',)], cur.fetchall())
             self.assertFalse(cur.nextset())


### PR DESCRIPTION
Please take a look at this pull request.
Currently any assigning select (or `set`) breaks result set.
Assigning select sends no result token, but does send TDS_DONE_TOKEN with both TDS_DONE_MORE_RESULTS and TDS_DONE_COUNT flags.
As a result `find_result_or_done` exits prematurely and the rest of result sets are ignored.
Change I made fixes the problem, but I'm not sure about what to do with other functions like `process_rpc`.