### PR TITLE
additional type objects, needed to distinguish between xml/integer/real

### DIFF
--- a/pytds/tds.py
+++ b/pytds/tds.py
@@ -555,6 +555,7 @@ class DBAPITypeObject:
         else:
             return -1
 
+# standard dbapi type objects
 STRING = DBAPITypeObject(SYBVARCHAR, SYBCHAR, SYBTEXT,
                          XSYBNVARCHAR, XSYBNCHAR, SYBNTEXT,
                          XSYBVARCHAR, XSYBCHAR, SYBMSXML)
@@ -565,6 +566,11 @@ DATETIME = DBAPITypeObject(SYBDATETIME, SYBDATETIME4, SYBDATETIMN)
 DECIMAL = DBAPITypeObject(SYBMONEY, SYBMONEY4, SYBMONEYN, SYBNUMERIC,
                           SYBDECIMAL)
 ROWID = DBAPITypeObject()
+
+# non-standard, but useful type objects
+INTEGER = DBAPITypeObject(SYBBIT, SYBBITN, SYBINT1, SYBINT2, SYBINT4, SYBINT8, SYBINTN)
+REAL = DBAPITypeObject(SYBREAL, SYBFLT8, SYBFLTN)
+XML = DBAPITypeObject(SYBMSXML)
 
 
 # stored procedure output parameter

--- a/pytds/tds.py
+++ b/pytds/tds.py
@@ -1512,9 +1512,6 @@ class NVarChar71(NVarChar70):
 
 
 class NVarChar72(NVarChar71):
-    def get_typeid(self):
-        return self.type
-
     @classmethod
     def from_stream(cls, r):
         size = r.get_usmallint()
@@ -1571,6 +1568,9 @@ class Xml(NVarCharMax):
     def __init__(self, schema={}):
         super(Xml, self).__init__(0)
         self._schema = schema
+
+    def get_typeid(self):
+        return self.type
 
     def get_declaration(self):
         return self.declaration

--- a/pytds/tds.py
+++ b/pytds/tds.py
@@ -605,7 +605,7 @@ class Binary(bytes):
         return 'Binary({0})'.format(super(Binary, self).__repr__())
 
 
-class _Default:
+class _Default(object):
     pass
 
 default = _Default()
@@ -3180,6 +3180,8 @@ class _TdsSession(object):
         if value is default:
             column.flags |= fDefaultValue
             value = None
+            if value_type is _Default:
+                value_type = None
 
         column.value = value
         if column.type is None:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -26,7 +26,8 @@ from pytds import (
     connect, ProgrammingError, TimeoutError, Time, SimpleLoadBalancer, LoginError,
     Error, IntegrityError, Timestamp, DataError, DECIMAL, Date, Binary, DateTime,
     IS_TDS73_PLUS, IS_TDS71_PLUS, NotSupportedError, TDS73, TDS71, TDS72, TDS70,
-    output, default, InterfaceError, TDS_ENCRYPTION_OFF)
+    output, default, InterfaceError, TDS_ENCRYPTION_OFF,
+    STRING, BINARY, NUMBER, DATETIME, DECIMAL, INTEGER, REAL, XML)
 from pytds.tds import (
     _TdsSocket, _TdsSession, TDS_ENCRYPTION_REQUIRE, Column, Bit, Int, SmallInt,
     NVarChar72, TinyInt, IntN, BigInt, Real, Float, FloatN, Collation,
@@ -1627,6 +1628,31 @@ end
 
             result = cur.fetchall()
             self.assertEqual(result[0], expected)
+
+    def test_type_objects(self):
+        with self._connect() as con:
+            cur = con.cursor()
+            cur.execute("""
+select cast(0 as varchar), 
+       cast(1 as binary),
+       cast(2 as int),
+       cast(3 as real),
+       cast(4 as decimal),
+       cast('2005' as datetime),
+       cast('6' as xml)
+""")
+            self.assertTrue(cur.description)
+            col_types = [col[1] for col in cur.description]
+            self.assertEqual(col_types[0], STRING)
+            self.assertEqual(col_types[1], BINARY)
+            self.assertEqual(col_types[2], NUMBER)
+            self.assertEqual(col_types[2], INTEGER)
+            self.assertEqual(col_types[3], NUMBER)
+            self.assertEqual(col_types[3], REAL)
+            # self.assertEqual(col_types[4], NUMBER) ?
+            self.assertEqual(col_types[4], DECIMAL)
+            self.assertEqual(col_types[5], DATETIME)
+            self.assertEqual(col_types[6], XML)
 
 
 @unittest.skipUnless(LIVE_TEST, "requires HOST variable to be set")


### PR DESCRIPTION
Changes:
1. added INTEGER/REAL type objects
2. added XML type object, fixed get_typeid for XML which used to return wrong value
3. added test for type objects


Note 1: for some reason diff on the left side shows old changes:

a) making _Default inherit from object
b) replace NoneType -> type(None) for python3
c) checking if value_type is _Default

All of these changes were part of default_params_fix pull request merged some time ago.
I'm not quite sure what's happening here.


Note 2: shouldn't all DECIMAL types also be part of NUMBER type object?
I.e. I expect _all_ numbers to match with NUMBER type object. If necessary they can be distinguished further by comparing them to REAL/INTEGER/DECIMAL type objects.