### PR TITLE
sqlalchemy/server side cursors

### DIFF
--- a/pytds/__init__.py
+++ b/pytds/__init__.py
@@ -631,6 +631,8 @@ class Cursor(six.Iterator):
         """
         conn = self._assert_open()
         conn._try_activate_cursor(self)
+        if operation[:3] == "sp_":
+            return self._callproc(operation, params)
         self._execute(operation, params)
 
     def _begin_tran(self, isolation_level):

--- a/pytds/tds.py
+++ b/pytds/tds.py
@@ -2855,6 +2855,18 @@ class _TdsSession(object):
                 value = curcol.type.read(r)
             self.row[i] = value
 
+    def process_tabname(self):
+        r = self._reader
+        total_length = r.get_smallint()
+        if not IS_TDS71_PLUS(self):
+            name_length = r.get_smallint()
+        skipall(r, total_length)
+
+    def process_colinfo(self):
+        r = self._reader
+        total_length = r.get_smallint()
+        skipall(r, total_length)
+
     def process_orderby(self):
         """ Reads and processes ORDER stream
 
@@ -3856,6 +3868,8 @@ _token_map = {
     TDS7_RESULT_TOKEN: lambda self: self.tds7_process_result(),
     TDS_ROW_TOKEN: lambda self: self.process_row(),
     TDS_NBC_ROW_TOKEN: lambda self: self.process_nbcrow(),
+    TDS_TABNAME_TOKEN: lambda self: self.process_tabname(),
+    TDS_COLINFO_TOKEN: lambda self: self.process_colinfo(),
     TDS_ORDERBY2_TOKEN: lambda self: self.process_orderby2(),
     TDS_ORDERBY_TOKEN: lambda self: self.process_orderby(),
     TDS_RETURNSTATUS_TOKEN: lambda self: self.process_returnstatus(),


### PR DESCRIPTION
Hello,

I'm preparing sqlalchemy patches with pytds as connector, but for first (dialects/mssql/base.py) patch sqlalchemy requires results from execute when calling sp_columns:
        # We also run an sp_columns to check for identity columns:
        if self.driver == 'pytds':
            cursor = connection.execute("sp_columns",  {
                "@table_name": tablename,
                "@table_owner": owner
            })
        else:
            cursor = connection.execute("sp_columns @table_name = '%s', "
                                    "@table_owner = '%s'"
                                    % (tablename, owner))

so small fix in pytds execute method.

Second one is bit bigger - support for missing tokens in tds protocol for server side cursors as in example:
def main():
    con = pytds.connect(
        '127.0.0.1',
        'model',
        'sa',
        'admin1!',
        port=14333,
        row_strategy = pytds.dict_row_strategy,
    )
    cur = con.cursor()
    sqls = [
        '''\
DECLARE kurs
CURSOR GLOBAL SCROLL STATIC READ_ONLY FOR
SELECT
    name, database_id
FROM sys.databases
ORDER BY
    database_id
''',
        'OPEN kurs',
        'SELECT @@CURSOR_ROWS AS nrows', None,
        True,
        'FETCH NEXT FROM kurs', None,
        True,
        'FETCH NEXT FROM kurs', None,
        'FETCH NEXT FROM kurs', None,
        'FETCH LAST FROM kurs', None,
        'CLOSE kurs',
    ]
    for sql in sqls:
        if sql is None:
            rec = cur.fetchone()
            print rec
        elif sql is True:
            print cur.description
        else:
            cur.execute(sql)
    cur.close()
    con.close()
main()

my result is:
{u'nrows': 330}
((u'nrows', 56, None, None, None, None, 0),)
{u'database_id': 1, u'name': u'master', u'ROWSTAT': 1}
((u'name', 231, None, 128, None, None, 0), (u'database_id', 56, None, None, None, None, 0), (u'ROWSTAT', 56, None, None, None, None, 0))
{u'database_id': 2, u'name': u'tempdb', u'ROWSTAT': 1}
{u'database_id': 3, u'name': u'model', u'ROWSTAT': 1}
{u'database_id': 330, u'name': u'VSPOLANDK', u'ROWSTAT': 1}


