### PR TITLE
Python 2.6 requires format field names

### DIFF
--- a/pytds/collate.py
+++ b/pytds/collate.py
@@ -207,7 +207,7 @@ class Collation(object):
         self.version = version
 
     def __repr__(self):
-        return 'Collation(lcid={}, sort_id={}, ignore_case={}, ignore_accent={}, ignore_width={}, ignore_kana={}, binary={}, binary2={}, version={})'.format(
+        return 'Collation(lcid={0}, sort_id={1}, ignore_case={2}, ignore_accent={3}, ignore_width={4}, ignore_kana={5}, binary={6}, binary2={7}, version={8})'.format(
             self.lcid,
             self.sort_id,
             self.ignore_case,


### PR DESCRIPTION
Here's a minor change so pytds works with python 2.6. I noticed the problem when trying to load help(pytds). Actually using pytds seems to work fine (assuming you're not using a collation).