### PR TITLE
Properly passing raw bytes to and from sql server when `bytes_to_unicode` is set to false

### DIFF
--- a/pytds/tds_types.py
+++ b/pytds/tds_types.py
@@ -706,7 +706,7 @@ class VarCharMaxSerializer(VarChar72Serializer):
         if login.bytes_to_unicode:
             return ''.join(tds_base.iterdecode(r.chunks(), self._codec))
         else:
-            return ''.join(r.chunks())
+            return six.b('').join(r.chunks())
 
 
 class NVarChar70Serializer(BaseTypeSerializer):

--- a/pytds/tds_types.py
+++ b/pytds/tds_types.py
@@ -637,8 +637,10 @@ class VarChar70Serializer(BaseTypeSerializer):
         if val is None:
             w.put_smallint(-1)
         else:
-            val = tds_base.force_unicode(val)
-            val, _ = self._codec.encode(val)
+            if w._tds._tds._login.bytes_to_unicode:
+                val = tds_base.force_unicode(val)
+            if isinstance(val, six.text_type):
+                val, _ = self._codec.encode(val)
             w.put_smallint(len(val))
             w.write(val)
 
@@ -646,7 +648,10 @@ class VarChar70Serializer(BaseTypeSerializer):
         size = r.get_smallint()
         if size < 0:
             return None
-        return r.read_str(size, self._codec)
+        if r._session._tds._login.bytes_to_unicode:
+            return r.read_str(size, self._codec)
+        else:
+            return tds_base.readall(r, size)
 
 
 class VarChar71Serializer(VarChar70Serializer):
@@ -683,8 +688,10 @@ class VarCharMaxSerializer(VarChar72Serializer):
         if val is None:
             w.put_uint8(tds_base.PLP_NULL)
         else:
-            val = tds_base.force_unicode(val)
-            val, _ = self._codec.encode(val)
+            if w._tds._tds._login.bytes_to_unicode:
+                val = tds_base.force_unicode(val)
+            if isinstance(val, six.text_type):
+                val, _ = self._codec.encode(val)
             w.put_int8(len(val))
             if len(val) > 0:
                 w.put_int(len(val))
@@ -692,10 +699,14 @@ class VarCharMaxSerializer(VarChar72Serializer):
             w.put_int(0)
 
     def read(self, r):
+        login = r._session._tds._login
         r = PlpReader(r)
         if r.is_null():
             return None
-        return ''.join(tds_base.iterdecode(r.chunks(), self._codec))
+        if login.bytes_to_unicode:
+            return ''.join(tds_base.iterdecode(r.chunks(), self._codec))
+        else:
+            return ''.join(r.chunks())
 
 
 class NVarChar70Serializer(BaseTypeSerializer):
@@ -854,8 +865,10 @@ class Text70Serializer(BaseTypeSerializer):
         if val is None:
             w.put_int(-1)
         else:
-            val = tds_base.force_unicode(val)
-            val, _ = self._codec.encode(val)
+            if w._tds._tds._login.bytes_to_unicode:
+                val = tds_base.force_unicode(val)
+            if isinstance(val, six.text_type):
+                val, _ = self._codec.encode(val)
             w.put_int(len(val))
             w.write(val)
 
@@ -866,7 +879,10 @@ class Text70Serializer(BaseTypeSerializer):
         tds_base.readall(r, size)  # textptr
         tds_base.readall(r, 8)  # timestamp
         colsize = r.get_int()
-        return r.read_str(colsize, self._codec)
+        if r._session._tds._login.bytes_to_unicode:
+            return r.read_str(colsize, self._codec)
+        else:
+            return tds_base.readall(r, colsize)
 
 
 class Text71Serializer(Text70Serializer):

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -1544,6 +1544,7 @@ class TestRawBytes(unittest.TestCase):
     def setUp(self):
         kwargs = settings.CONNECT_KWARGS.copy()
         kwargs['bytes_to_unicode'] = False
+        kwargs['database'] = 'master'
         self.conn = connect(*settings.CONNECT_ARGS, **kwargs)
 
     def test_fetch(self):

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -1555,5 +1555,9 @@ class TestRawBytes(unittest.TestCase):
         self.assertIsInstance(cur.execute_scalar("select %s", [six.u('abc')]), six.text_type)
         self.assertIsInstance(cur.execute_scalar("select %s", [six.b('abc')]), six.binary_type)
 
-        self.assertEquals(six.b('\x01\x02\x03'), cur.execute_scalar("select cast(0x010203 as varchar(max))"))
-        self.assertEquals(six.b('\x01\x02\x03'), cur.execute_scalar("select %s", [six.b('\x01\x02\x03')]))
+        rawBytes = six.b('\x01\x02\x03')
+        self.assertEquals(rawBytes, cur.execute_scalar("select cast(0x010203 as varchar(max))"))
+        self.assertEquals(rawBytes, cur.execute_scalar("select %s", [rawBytes]))
+
+        utf8char = six.b('\xee\xb4\xba')
+        self.assertEquals(utf8char, cur.execute_scalar("select %s", [utf8char]))

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -1551,6 +1551,7 @@ class TestRawBytes(unittest.TestCase):
 
         self.assertIsInstance(cur.execute_scalar("select cast('abc' as nvarchar(max))"), six.text_type)
         self.assertIsInstance(cur.execute_scalar("select cast('abc' as varchar(max))"), six.binary_type)
+        self.assertIsInstance(cur.execute_scalar("select cast('abc' as text)"), six.binary_type)
 
         self.assertIsInstance(cur.execute_scalar("select %s", [six.u('abc')]), six.text_type)
         self.assertIsInstance(cur.execute_scalar("select %s", [six.b('abc')]), six.binary_type)


### PR DESCRIPTION
Please see #73 for details.

I tried to pass `bytes_to_unicode` to serializers via constructor, but it proven to be much harder than I expected. `bytes_to_unicode` defaults to `True` for connections, but for some unit tests it defaults to `False`. I got dozens of errors at random places and couldn't fix it without modifying lots of tests.

Fixes #73
