### PR TITLE
NTLMAuth Domain Change

### DIFF
--- a/pytds/__init__.py
+++ b/pytds/__init__.py
@@ -15,7 +15,7 @@ from six.moves import xrange
 
 from pytds.tds_types import NVarCharType
 from . import lcid
-from . import tz
+import pytds.tz
 from .tds import (
     SimpleLoadBalancer,
     _TdsSocket, tds7_get_instances,
@@ -1106,7 +1106,7 @@ def connect(dsn=None, database=None, user=None, password=None, timeout=None,
     if use_tz:
         login.client_tz = use_tz
     else:
-        login.client_tz = tz.local
+        login.client_tz = pytds.tz.local
 
     # that will set:
     # ANSI_DEFAULTS to ON,

--- a/pytds/tds.py
+++ b/pytds/tds.py
@@ -1366,6 +1366,7 @@ class _TdsSession(object):
         # self.sock = ssl.wrap_socket(self.sock, ssl_version=ssl.PROTOCOL_SSLv3)
 
     def tds7_send_login(self, login):
+        # https://msdn.microsoft.com/en-us/library/dd304019.aspx
         option_flag2 = login.option_flag2
         user_name = login.user_name
         if len(user_name) > 128:


### PR DESCRIPTION
I added a domain keyword argument to NtlmAuth. NTLM authorization fails on MacOS unless this value is updated. The change preserves its current behavior while allowing users to override the default without modifying the library source-code.