### PR TITLE
Update login.py

### DIFF
--- a/src/pytds/login.py
+++ b/src/pytds/login.py
@@ -98,11 +98,11 @@ class NtlmAuth(object):
     :param password: User password
     :type password: str
     """
-    def __init__(self, user_name, password):
+    def __init__(self, user_name, password, domain='workspace'):
         if '\\' in user_name:
             self._domain, self._user = user_name.split('\\', 1)
         else:
-            self._domain = 'workspace'
+            self._domain = domain
             self._user = user_name
         self._password = password
 


### PR DESCRIPTION
Added keyword argument for NTLM Auth domain. The hardcoded 'workspace' does not work on MacOS. This isn't a breaking change -- it preserves existing library behavior but is now more flexible without modifying the library code for each Windows domain.