### PR TITLE
Added new method bulk_insert with more control over the column types …

### DIFF
--- a/src/pytds/tds_base.py
+++ b/src/pytds/tds_base.py
@@ -592,6 +592,7 @@ def total_seconds(td):
 
 
 class Column(CommonEqualityMixin):
+    fNotNull = 0
     fNullable = 1
     fCaseSen = 2
     fReadWrite = 8


### PR DESCRIPTION
…and direct support for python objects as data instead of a .cvs file

To support column types and a csv file will require additional modifications to parse the types from the CSV reader to their proper types so they can be serialized.