### PR TITLE
Handle decimals correctly even with default decimal context precision.

### DIFF
--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -50,9 +50,6 @@ import settings
 
 logger = logging.getLogger(__name__)
 
-# set decimal precision to match mssql maximum precision
-getcontext().prec = 38
-
 LIVE_TEST = getattr(settings, 'LIVE_TEST', True)
 
 

--- a/tests/connected_test.py
+++ b/tests/connected_test.py
@@ -1,7 +1,7 @@
 # vim: set fileencoding=utf8 :
 from __future__ import with_statement
 from __future__ import unicode_literals
-from decimal import Decimal, getcontext
+from decimal import Decimal, Context
 import uuid
 import datetime
 import logging
@@ -363,7 +363,7 @@ def test_empty_query(cursor):
                                  Decimal('1234000'),
                                  Decimal('9' * 38),
                                  Decimal('0.' + '9' * 38),
-                                 -Decimal('9' * 38),
+                                 Decimal('-' + ('9' * 38), Context(prec=38)),
                                  Decimal('1E10'),
                                  Decimal('1E-10'),
                                  Decimal('0.{0}1'.format('0' * 37)),


### PR DESCRIPTION
This has the side effect of fixing integration test failures when testing connected_test.py by itself. getcontext().prec = 38 was run in all_test.py which gets run before connected_test.py if you are running all tests, but does not get run if you are only running tests in connected_test.py.

Fixes #90