### PR TITLE
Allow specifying column types and providing data directly in bulk copies

### DIFF
--- a/src/pytds/__init__.py
+++ b/src/pytds/__init__.py
@@ -893,13 +893,14 @@ class Cursor(six.Iterator):
         """
         pass
 
-    def copy_to(self, file, table_or_view, sep='\t', columns=None,
+    def copy_to(self, file=None, table_or_view=None, sep='\t', columns=None,
                 check_constraints=False, fire_triggers=False, keep_nulls=False,
                 kb_per_batch=None, rows_per_batch=None, order=None, tablock=False,
-                schema=None, null_string=None):
+                schema=None, null_string=None, data=None):
         """ *Experimental*. Efficiently load data to database from file using ``BULK INSERT`` operation
 
-        :param file: Source file-like object, should be in csv format
+        :param file: Source file-like object, should be in csv format. Specify
+          either this or data, not both.
         :param table_or_view: Destination table or view in the database
         :type table_or_view: str
 
@@ -907,8 +908,17 @@ class Cursor(six.Iterator):
 
         :keyword sep: Separator used in csv file
         :type sep: str
-        :keyword columns: List of column names in target table to insert to,
-          if not provided will insert into all columns
+        :keyword columns: List of Column objects or column names in target
+          table to insert to. SQL Server will do some conversions, so these
+          may not have to match the actual table definition exactly.
+          If not provided will insert into all columns assuming nvarchar(4000)
+          NULL for all columns.
+          If only the column name is provided, the type is assumed to be
+          nvarchar(4000) NULL.
+          If rows are given with file, you cannot specify non-string data
+          types.
+          If rows are given with data, the values must be a type supported by
+          the serializer for the column in tds_types.
         :type columns: list
         :keyword check_constraints: Check table constraints for incoming data
         :type check_constraints: bool
@@ -929,24 +939,38 @@ class Cursor(six.Iterator):
         :type order: list
         :keyword tablock: Enable or disable table lock for the duration of bulk load
         :keyword schema: Name of schema for table or view, if not specified default schema will be used
-        :keyword null_string: String that should be interpreted as a NULL when reading the CSV file.
+        :keyword null_string: String that should be interpreted as a NULL when
+          reading the CSV file. Has no meaning if using data instead of file.
+        :keyword data: The data to insert as an iterable of rows, which are
+          iterables of values. Specify either this or file, not both.
         """
         conn = self._conn()
-        import csv
-        reader = csv.reader(file, delimiter=sep)
+        rows = None
+        if data is None:
+            import csv
+            reader = csv.reader(file, delimiter=sep)
 
-        if null_string is not None:
-            def _convert_null_strings(csv_reader):
-                for row in csv_reader:
-                    yield [r if r != null_string else None for r in row]
+            if null_string is not None:
+                def _convert_null_strings(csv_reader):
+                    for row in csv_reader:
+                        yield [r if r != null_string else None for r in row]
 
-            reader = _convert_null_strings(reader)
+                reader = _convert_null_strings(reader)
+
+            rows = reader
+        else:
+            rows = data
 
         obj_name = tds_base.tds_quote_id(table_or_view)
         if schema:
             obj_name = '{0}.{1}'.format(tds_base.tds_quote_id(schema), obj_name)
         if columns:
-            metadata = [Column(name=name, type=NVarCharType(size=4000), flags=Column.fNullable) for name in columns]
+            metadata = []
+            for column in columns:
+                if isinstance(column, Column):
+                    metadata.append(column)
+                else:
+                    metadata.append(Column(name=column, type=NVarCharType(size=4000), flags=Column.fNullable))
         else:
             self.execute('select top 1 * from {} where 1<>1'.format(obj_name))
             metadata = [Column(name=col[0], type=NVarCharType(size=4000), flags=Column.fNullable if col[6] else 0)
@@ -973,7 +997,7 @@ class Cursor(six.Iterator):
             with_part = 'WITH ({0})'.format(','.join(with_opts))
         operation = 'INSERT BULK {0}({1}) {2}'.format(obj_name, col_defs, with_part)
         self.execute(operation)
-        self._session.submit_bulk(metadata, reader)
+        self._session.submit_bulk(metadata, rows)
         self._session.process_simple_request()
 
 

--- a/tests/connected_test.py
+++ b/tests/connected_test.py
@@ -239,6 +239,27 @@ def test_bulk_insert_with_keyword_column_name(cursor):
     assert cur.fetchall() == [(42, 'foo'), (74, 'bar')]
 
 
+def test_bulk_insert_with_direct_data(cursor):
+    cur = cursor
+    cur.execute('create table test_table(num int, data nvarchar(max))')
+
+    data = [
+        [42, 'foo'],
+        [57, ''],
+        [66, None],
+        [74, 'bar']
+    ]
+
+    column_types = [
+        pytds.tds_base.Column('num', pytds.tds_types.IntType(), pytds.tds_base.Column.fNullable),
+        pytds.tds_base.Column('data', pytds.tds_types.NVarCharMaxType(), pytds.tds_base.Column.fNullable)
+    ]
+
+    cur.copy_to(data=data, table_or_view='test_table', columns=column_types)
+    cur.execute('select num, data from test_table')
+    assert cur.fetchall() == [(42, 'foo'), (57, ''), (66, None), (74, 'bar')]
+
+
 def test_table_valued_type_autodetect(separate_db_connection):
     def rows_gen():
         yield (1, 'test1')


### PR DESCRIPTION
This allows inserting values of types not compatible with nvarchar(4000), such as nvarchar(max).

This reuses the existing `columns` parameter and checks if values are `Column` objects. However I chose to add a new parameter for passing data as python values instead of csv/tsv for a couple reasons. One is that calling a sequence of python values "file" is a poor name. The other, arguably more important, reason is that there may be users depending on being able to provide `Iterable[Iterable[str]]` for `file` in order to stream data from memory on the fly (writing one csv/tsv row at a time using `yield`) without having to write out to disk first. That's what I was going to do until I ran into not being able to bulk insert into nvarchar(max) columns due to everything being typed as nvarchar(4000) by default. Assuming `file` is python values instead of csv/tsv if it's not a file-like object would break consumers of pytds using it in that way.

Fixes #84