### PR TITLE
Fix for 'DeprecationWarning: invalid escape sequence \<'

### DIFF
--- a/src/pytds/__init__.py
+++ b/src/pytds/__init__.py
@@ -1153,7 +1153,7 @@ def connect(dsn=None, database=None, user=None, password=None, timeout=None,
     """
     Opens connection to the database
 
-    :keyword dsn: SQL server host and instance: <host>[\<instance>]
+    :keyword dsn: SQL server host and instance: <host>[\\<instance>]
     :type dsn: string
     :keyword failover_partner: secondary database host, used if primary is not accessible
     :type failover_partner: string


### PR DESCRIPTION
The pydoc for `connect` contains an invalid Python escape sequence. This throws a warning on screen when running with `PYTHONWARNINGS="default"`.

An alternative fix would be to mark the whole text as a string literal: `r"""<host>[\<instance>]"""` does not show any warnings either.