### PR TITLE
Fix SSO with instance name instead of port

### DIFF
--- a/src/pytds/__init__.py
+++ b/src/pytds/__init__.py
@@ -1290,7 +1290,7 @@ def connect(dsn=None, database=None, user=None, password=None, timeout=None,
         parsed_servers.append((host, port, instance))
 
     if use_sso:
-        spn = "MSSQLSvc@{}:{}".format(parsed_servers[0][0], parsed_servers[0][1])
+        spn = "MSSQLSvc@{}:{}".format(parsed_servers[0][0], parsed_servers[0][1] or parsed_servers[0][2])
         from . import login as pytds_login
         try:
             login.auth = pytds_login.SspiAuth(spn=spn)


### PR DESCRIPTION
When a named instance instead of a port is used, Kerberos logins failed because the spn string was
 "MSSQLSvc@SERVER_NAME:None" instead of "MSSQLSvc@SERVER_NAME:INSTANCE_NAME".
When "port" is None (parsed_servers[0][1]), "instance" (parsed_servers[0][2]) should be used.