### PR TITLE
space in column name

### DIFF
--- a/src/pytds/__init__.py
+++ b/src/pytds/__init__.py
@@ -701,7 +701,7 @@ class Cursor(six.Iterator):
                     if value is None:
                         rename[name] = 'NULL'
                     else:
-                        mssql_name = '@{0}'.format(name)
+                        mssql_name = '@{0}'.format(name.replace(' ', '_'))
                         rename[name] = mssql_name
                         named_params[mssql_name] = value
                 operation = operation % rename


### PR DESCRIPTION
I know it's a bad idea to have a space in the column name, but others allow it.

<pre>
import pytds

table_name = "issue_7"
with pytds.connect('127.0.0.1', 'testing', 'sa', 'SaAdmin1@') as conn:
    with conn.cursor() as cur:
        sql = f"DROP TABLE IF EXISTS {table_name}"
        cur.execute(sql)
        sql = f"CREATE TABLE {table_name} (id int primary key, [my column] int)"
        cur.execute(sql)

        sql = "INSERT INTO issue_7 (id, [my column]) VALUES (%(id)s, %(my column)s)"
        parameters = {'id': 1, 'my column': 123}
        cur.execute(sql, parameters)
</pre>