### PR TITLE
update add_extension() call for modern cryptography

### DIFF
--- a/tests/utils_35.py
+++ b/tests/utils_35.py
@@ -75,16 +75,16 @@ def generate_root_certificate(private_key: rsa.RSAPrivateKey) -> x509.Certificat
         .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=1)) \
         .serial_number(1) \
         .public_key(private_key.public_key()) \
-        .add_extension(extension=x509.BasicConstraints(ca=True, path_length=1), critical=True) \
-        .add_extension(extension=x509.KeyUsage(digital_signature=False,
-                                               content_commitment=False,
-                                               key_encipherment=False,
-                                               data_encipherment=False,
-                                               key_agreement=False,
-                                               key_cert_sign=True,
-                                               crl_sign=True,
-                                               encipher_only=False,
-                                               decipher_only=False,
-                                               ), critical=True) \
+        .add_extension(x509.BasicConstraints(ca=True, path_length=1), critical=True) \
+        .add_extension(x509.KeyUsage(digital_signature=False,
+                                     content_commitment=False,
+                                     key_encipherment=False,
+                                     data_encipherment=False,
+                                     key_agreement=False,
+                                     key_cert_sign=True,
+                                     crl_sign=True,
+                                     encipher_only=False,
+                                     decipher_only=False,
+                                     ), critical=True) \
         .sign(private_key=private_key, algorithm=hashes.SHA256(), backend=backend)
 


### PR DESCRIPTION
in recent versions of cryptography they renamed some of the arguments to add_extension(); without this change tests generate exceptions like:

```
_____ ERROR at setup of test_encrypted_socket
    @pytest.fixture(scope='module')
    def certificate_key():
        import utils_35 as utils
        from cryptography import x509
        address = ('127.0.0.1', 1434)
>       test_ca = utils.TestCA()

tests/unit_test.py:1110: 
_____ 
tests/utils_35.py:21: in __init__
    self._root_ca = generate_root_certificate(self._root_key)
______

private_key = <cryptography.hazmat.backends.openssl.rsa._RSAPrivateKey object at 0x7f3917135ab0>

    def generate_root_certificate(private_key: rsa.RSAPrivateKey) -> x509.Certificate:
        backend = cryptography.hazmat.backends.default_backend()
        subject = x509.Name(
            [x509.NameAttribute(
                x509.oid.NameOID.COMMON_NAME, 'root'
            )]
        )
        builder = x509.CertificateBuilder()
>       return builder.subject_name(subject).issuer_name(subject) \
            .not_valid_before(datetime.datetime.utcnow()) \
            .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=1)) \
            .serial_number(1) \
            .public_key(private_key.public_key()) \
            .add_extension(extension=x509.BasicConstraints(ca=True, path_length=1), critical=True) \
            .add_extension(extension=x509.KeyUsage(digital_signature=False,
                                                   content_commitment=False,
                                                   key_encipherment=False,
                                                   data_encipherment=False,
                                                   key_agreement=False,
                                                   key_cert_sign=True,
                                                   crl_sign=True,
                                                   encipher_only=False,
                                                   decipher_only=False,
                                                   ), critical=True) \
            .sign(private_key=private_key, algorithm=hashes.SHA256(), backend=backend)
E       TypeError: CertificateBuilder.add_extension() got an unexpected keyword argument 'extension'

tests/utils_35.py:73: TypeError
```