### PR TITLE
Fix AppVeyor tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,13 +13,13 @@ environment:
       SQLINSTANCE: SQL2016
     - PYTHON: "C:\\Python38"
       SQLINSTANCE: SQL2016
-    - PYTHON: "C:\\Python39"
+    - PYTHON: "C:\\Python38-x64"
       SQLINSTANCE: SQL2016
-    - PYTHON: "C:\\Python310"
+    - PYTHON: "C:\\Python38-x64"
       SQLINSTANCE: SQL2014
-    - PYTHON: "C:\\Python311"
+    - PYTHON: "C:\\Python38-x64"
       SQLINSTANCE: SQL2012SP1
-    - PYTHON: "C:\\Python311-x64"
+    - PYTHON: "C:\\Python38-x64"
       SQLINSTANCE: SQL2008R2SP2
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: 1.0.{build}
 
-os: Windows Server 2012 R2
+os: Windows Server 2019
 
 environment:
   INAPPVEYOR: 1
@@ -19,7 +19,7 @@ environment:
       SQLINSTANCE: SQL2014
     - PYTHON: "C:\\Python311"
       SQLINSTANCE: SQL2012SP1
-    - PYTHON: "C:\\Python311"
+    - PYTHON: "C:\\Python311-x64"
       SQLINSTANCE: SQL2008R2SP2
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: 1.0.{build}
 
-os: Visual Studio 2022
+os: Windows Server 2012 R2
 
 environment:
   INAPPVEYOR: 1
@@ -23,6 +23,8 @@ environment:
       SQLINSTANCE: SQL2008R2SP2
 
 install:
+  - dir c:\
+  - dir %PYTHON%
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - python --version
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,15 +11,15 @@ environment:
   matrix:
     - PYTHON: "C:\\Python37"
       SQLINSTANCE: SQL2016
-    - PYTHON: "C:\\Python36"
+    - PYTHON: "C:\\Python38"
       SQLINSTANCE: SQL2016
-    - PYTHON: "C:\\Python35"
+    - PYTHON: "C:\\Python39"
       SQLINSTANCE: SQL2016
-    - PYTHON: "C:\\Python36"
+    - PYTHON: "C:\\Python310"
       SQLINSTANCE: SQL2014
-    - PYTHON: "C:\\Python36"
+    - PYTHON: "C:\\Python311"
       SQLINSTANCE: SQL2012SP1
-    - PYTHON: "C:\\Python36"
+    - PYTHON: "C:\\Python311"
       SQLINSTANCE: SQL2008R2SP2
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,8 +9,6 @@ environment:
   SQLPASSWORD: Password12!
   DATABASE: test
   matrix:
-    #- PYTHON: "C:\\Python38"
-    #  SQLINSTANCE: SQL2016
     - PYTHON: "C:\\Python37"
       SQLINSTANCE: SQL2016
     - PYTHON: "C:\\Python37-x64"
@@ -23,8 +21,6 @@ environment:
       SQLINSTANCE: SQL2008R2SP2
 
 install:
-  - dir c:\
-  - dir %PYTHON%
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - python --version
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: 1.0.{build}
 
-os: Windows Server 2019
+os: Visual Studio 2022
 
 environment:
   INAPPVEYOR: 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,17 +9,17 @@ environment:
   SQLPASSWORD: Password12!
   DATABASE: test
   matrix:
+    #- PYTHON: "C:\\Python38"
+    #  SQLINSTANCE: SQL2016
     - PYTHON: "C:\\Python37"
       SQLINSTANCE: SQL2016
-    - PYTHON: "C:\\Python38"
+    - PYTHON: "C:\\Python37-x64"
       SQLINSTANCE: SQL2016
-    - PYTHON: "C:\\Python38-x64"
-      SQLINSTANCE: SQL2016
-    - PYTHON: "C:\\Python38-x64"
+    - PYTHON: "C:\\Python37-x64"
       SQLINSTANCE: SQL2014
-    - PYTHON: "C:\\Python38-x64"
+    - PYTHON: "C:\\Python37-x64"
       SQLINSTANCE: SQL2012SP1
-    - PYTHON: "C:\\Python38-x64"
+    - PYTHON: "C:\\Python37-x64"
       SQLINSTANCE: SQL2008R2SP2
 
 install:

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,7 +1,7 @@
 pytest>=3.3.2
 pytest-cov
 codecov
-pyOpenSSL
+pyOpenSSL<=21.0.0
 pyDes
 ntlm-auth
 namedlist

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -4,7 +4,7 @@ codecov
 # pyOpenSSL 23.0.0 fails with error:
 # TypeError: deprecated() got an unexpected keyword argument 'name'
 # Example failing build: https://ci.appveyor.com/project/denisenkom/pytds/builds/46539355/job/aq6d65ej1oi0i59p
-pyOpenSSL<23.0.0
+pyOpenSSL<22.1.0
 pyDes
 ntlm-auth
 namedlist

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,7 +1,10 @@
 pytest>=3.3.2
 pytest-cov
 codecov
-pyOpenSSL<=21.0.0
+# pyOpenSSL 23.0.0 fails with error:
+# TypeError: deprecated() got an unexpected keyword argument 'name'
+# Example failing build: https://ci.appveyor.com/project/denisenkom/pytds/builds/46539355/job/aq6d65ej1oi0i59p
+pyOpenSSL<=22.0.0
 pyDes
 ntlm-auth
 namedlist

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -4,7 +4,7 @@ codecov
 # pyOpenSSL 23.0.0 fails with error:
 # TypeError: deprecated() got an unexpected keyword argument 'name'
 # Example failing build: https://ci.appveyor.com/project/denisenkom/pytds/builds/46539355/job/aq6d65ej1oi0i59p
-pyOpenSSL<=22.0.0
+pyOpenSSL<23.0.0
 pyDes
 ntlm-auth
 namedlist


### PR DESCRIPTION
Remove build for old Python versions (3.6 and older).  Add build for x64 bit Python versions, that is now the main Python version.

Restrict pyOpenSSL to version before 22.1.0. Build fails on that and newer versions.