### PR TITLE
fix(tls): parsing multiple SANs

### DIFF
--- a/src/pytds/tls.py
+++ b/src/pytds/tls.py
@@ -91,7 +91,7 @@ def verify_cb(conn, cert, err_num, err_depth, ret_code: int) -> bool:
 
 def is_san_matching(san: str, host_name: str) -> bool:
     for item in san.split(','):
-        dnsentry = item.lstrip('DNS:').strip()
+        dnsentry = item.strip().lstrip('DNS:').strip()
         # SANs are usually have form like: DNS:hostname
         if dnsentry == host_name:
             return True

--- a/tests/tls_san_test.py
+++ b/tests/tls_san_test.py
@@ -8,3 +8,9 @@ def test_san():
     assert is_san_matching("*.database.com", "test.database.com")
     assert not is_san_matching("database.com", "*.database.com")
     assert not is_san_matching("test.*.database.com", "test.subdomain.database.com") # That star should be at first position
+    # test stripping DNS:
+    assert is_san_matching("DNS:westus2-a.control.database.windows.net", "westus2-a.control.database.windows.net")
+    assert is_san_matching("DNS:*.database.windows.net", "my-sql-server.database.windows.net")
+    # test parsing multiple SANs
+    assert is_san_matching("DNS:westus2-a.control.database.windows.net,DNS:*.database.windows.net", "my-sql-server.database.windows.net")
+    assert is_san_matching("DNS:westus2-a.control.database.windows.net, DNS:*.database.windows.net", "my-sql-server.database.windows.net")


### PR DESCRIPTION
When pulling the cert from Azure SQL Server, the SANs looks something like this:
```
| Subject Alternative Name: DNS:cr5.westus2-a.control.database.windows.net, DNS:*.cr5.westus2-a.control.database.windows.net, DNS:westus2-a.control.database.windows.net, DNS:*.westus2-a.control.database.windows.net, DNS:*.database.windows.net, DNS:*.database.secure.windows.net, DNS:*.secondary.database.windows.net, DNS:*.mariadb.database.azure.com, DNS:*.mysql.database.azure.com, DNS:*.postgres.database.azure.com, DNS:*.sql.projectarcadia.net, DNS:*.sql.azuresynapse.net, DNS:*.sql.azuresynapse-dogfood.net, DNS:*.database-fleet.windows.net, DNS:*.secondary.database-fleet.windows.net, DNS:*.dualstack.database.windows.net
```

Since there is a space after the comma, the `DNS:` portion wasn't being stripped, causing `<my-sql-server>.database.windows.net` to not be a match. The last unit test case is an example of this scenario.