### PR TITLE
chore: remove use of pkg_resources for newer python versions

### DIFF
--- a/src/pytds/__init__.py
+++ b/src/pytds/__init__.py
@@ -66,12 +66,11 @@ from .tds_base import (
 
 
 from . import tls
-import pkg_resources  # type: ignore # fix later
 from .tds_base import logger
 
 __author__ = "Mikhail Denisenko <denisenkom@gmail.com>"
 try:
-    __version__ = pkg_resources.get_distribution("python-tds").version
+    __version__ = utils.package_version("python-tds")
 except Exception:
     __version__ = "DEV"
 

--- a/src/pytds/utils.py
+++ b/src/pytds/utils.py
@@ -4,10 +4,15 @@ other modules.
 """
 from __future__ import annotations
 import logging
+import sys
 import time
 import typing
 from collections.abc import Callable
 
+if sys.version_info < (3, 8):
+    import pkg_resources
+else:
+    from importlib import metadata
 
 logger = logging.getLogger("pytds")
 T = typing.TypeVar("T")
@@ -80,3 +85,9 @@ def ver_to_int(ver: str) -> int:
         return 0
     maj, minor, _ = ver.split(".")
     return (int(maj) << 24) + (int(minor) << 16)
+
+
+def package_version(name: str) -> str:
+    if sys.version_info < (3, 8):
+        return pkg_resources.get_distribution(name).version
+    return metadata.version(name)


### PR DESCRIPTION
`pkg_resources` is vastly seen as deprecated and in the latest Python version it has been removed entirely from being pre-installed as part of Python https://github.com/python/cpython/issues/95299

This results in the following error with Python 3.12 when using pytds:
```
.nox\system-3-12\Lib\site-packages\pytds\__init__.py:69: in <module>
    import pkg_resources  # type: ignore # fix later
E   ModuleNotFoundError: No module named 'pkg_resources'
```

To fix this we can leverage `importlib.metadata` as a replacement for `pkg_resources.get_distribution().version`