### PR TITLE
RELEASE.rst: make a release the modern way

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -12,17 +12,17 @@ Tag current commit by running:
 
  git tag -a <version>
 
+Install build and twine:
+
+ python3 -m pip install --user --upgrade twine build
+
 Check build:
 
- python setup.py sdist
+ python -m build
 
 Push to github:
 
  git push && git push --tags
-
-Install twine:
-
- python3 -m pip install --user --upgrade twine
 
 Upload to pypi:
 


### PR DESCRIPTION
Invoking directly setup.py is deprecated ([Why you shouldn't invoke setup.py directly](https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html). Plus, this old way of doing only produces sdist and not wheels, which are more modern, the norm now and way more faster to install (I noticed pytds was using the old way because PDM on my project was taking longer to install pytds).

This is a slight change and it's the "good" way to do it "today".
I am available if you have more questions.