### PR TITLE
Add Azure AD token authentication support (AzureTokenAuth) and expose…

### DIFF
--- a/src/pytds/__init__.py
+++ b/src/pytds/__init__.py
@@ -17,6 +17,7 @@ import pytds.tz
 from .connection import MarsConnection, NonMarsConnection, Connection
 from .cursor import Cursor  # noqa: F401 # export for backward compatibility
 from .login import KerberosAuth, SspiAuth, AuthProtocol  # noqa: F401 # export for backward compatibility
+from .azure_auth import AzureTokenAuth  # noqa: F401
 from .row_strategies import (
     tuple_row_strategy,
     list_row_strategy,  # noqa: F401 # export for backward compatibility

--- a/src/pytds/azure_auth.py
+++ b/src/pytds/azure_auth.py
@@ -1,0 +1,64 @@
+"""
+Azure AD authentication support for pytds.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Callable, Optional
+
+from pytds.tds_base import AuthProtocol
+
+logger = logging.getLogger(__name__)
+
+
+class AzureTokenAuth(AuthProtocol):
+    """Azure AD Token Authentication
+    
+    This class implements Azure AD token authentication for Azure SQL Database.
+    It allows authentication using an access token obtained from Azure AD.
+    
+    :param token: Azure AD access token (JWT)
+    :type token: str
+    :param token_callback: Optional callable that returns a token string. 
+                          If provided, will be called to get a fresh token when needed.
+    :type token_callback: Callable[[], str], optional
+    """
+    
+    def __init__(self, token: str = "", token_callback: Optional[Callable[[], str]] = None):
+        if not token and not token_callback:
+            raise ValueError("Either token or token_callback must be provided")
+        self._token = token
+        self._token_callback = token_callback
+        self._token_used = False
+    
+    def _get_token(self) -> str:
+        """Get the current token, calling the callback if needed"""
+        if self._token_used and self._token_callback:
+            self._token = self._token_callback()
+            self._token_used = False
+        return self._token
+    
+    def create_packet(self) -> bytes:
+        """Create the initial authentication packet with the token"""
+        token = self._get_token()
+        if not token:
+            raise ValueError("No token available for authentication")
+        
+        # The token is sent as a UTF-16LE encoded string with a 4-byte length prefix
+        token_bytes = token.encode('utf-16le')
+        packet = len(token_bytes).to_bytes(4, 'little') + token_bytes
+        self._token_used = True  # Mark token as used for this authentication attempt
+        return packet
+    
+    def handle_next(self, packet: bytes) -> bytes | None:
+        """Handle server response - not expecting any further tokens"""
+        # Azure SQL should not send any challenge after receiving the token
+        if packet:
+            logger.warning("Unexpected data received during Azure AD token authentication")
+        return None
+    
+    def close(self) -> None:
+        """Clean up any resources"""
+        # Clear the token from memory when done
+        self._token = ""
+        self._token_used = True


### PR DESCRIPTION
… via __init__.py

This PR introduces Azure Active Directory token–based authentication to the pytds driver.

Key highlights 
• Added new class 
```
AzureTokenAuth
 in 
src/pytds/azure_auth.py
```
 – Implements the AuthProtocol interface
– Accepts either a static token string or a callback for token refresh
– Encodes the token as UTF-16LE with length prefix and sends it in the initial login packet
– Clears sensitive token data on close

[/Users/sriramsowmithri/Desktop/pytds/pytds/src/pytds/azure_auth.py](url) in 
```
src/pytds/init.py
 for public use
• Updated docs (
AZURE_AD_AUTH.md
)
```
with usage examples, MSAL integration, security tips, and troubleshooting

**Benefits** 
• Enables secure Azure SQL Database connections using Azure AD access tokens
• No new required dependencies; users may supply their own token-acquisition logic or MSAL if desired
• Follows existing authentication patterns, ensuring minimal impact to existing codebases