### PR TITLE
feat: Add Azure SQL Federated Authentication (Token-Based)

### DIFF
--- a/src/pytds/__init__.py
+++ b/src/pytds/__init__.py
@@ -141,6 +141,7 @@ def connect(
     use_sso: bool = False,
     isolation_level: int = 0,
     access_token_callable: Callable[[], str] | None = None,
+    access_token: str | None = None,
 ):
     """
     Opens connection to the database
@@ -200,13 +201,18 @@ def connect(
              Cannot be used together with auth parameter.
     :keyword access_token_callable: Callable that returns a Federated Authentication Token
     :type access_token_callable: Callable[[], str]
+    :keyword access_token: string containing Federated Authentication Token
+    :type access_token: str
     :returns: An instance of :class:`Connection`
     """
     if use_sso and auth:
         raise ValueError("use_sso cannot be used with auth parameter defined")
 
-    if (user or password) and access_token_callable:
-        raise ValueError("user/password cannot be used with access_token_callable")
+    if (user or password) and (access_token_callable or access_token):
+        raise ValueError("user/password cannot be used with access_token or access_token_callable")
+
+    if access_token_callable and access_token:
+        raise ValueError("access_token cannot be used with access_token_callable")
 
     login = tds_base._TdsLogin()
     login.client_host_name = socket.gethostname()[:128]
@@ -231,6 +237,7 @@ def connect(
     login.validate_host = validate_host
     login.enc_login_only = enc_login_only
     login.access_token_callable = access_token_callable
+    login.access_token = access_token
 
     if cafile:
         if not tls.OPENSSL_AVAILABLE:

--- a/tests/test_fedauth.py
+++ b/tests/test_fedauth.py
@@ -55,15 +55,21 @@ class TestFedAuth(unittest.TestCase):
         self.assertTrue(mock_connect.called)
         
         # Check if the login object passed to _connect has the token set
-        # _connect args: login, host, port, ...
-        # args[0] is login object
+        # _connect is called with kwargs in __init__.py
         call_args = mock_connect.call_args
-        if call_args.args:
-            login_obj = call_args.args[0]
-        else:
-            login_obj = call_args.kwargs['login']
+        login_obj = call_args.kwargs['login']
             
         self.assertEqual(login_obj.access_token, token)
+
+    def test_connect_validation_errors(self):
+        """Verify that invalid combinations of parameters raise ValueError"""
+        # Case 1: user/password AND access_token
+        with self.assertRaisesRegex(ValueError, "user/password cannot be used with access_token"):
+            connect(dsn="localhost", user="user", password="password", access_token="token")
+
+        # Case 2: access_token AND access_token_callable
+        with self.assertRaisesRegex(ValueError, "access_token cannot be used with access_token_callable"):
+            connect(dsn="localhost", access_token="token", access_token_callable=lambda: "token")
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_fedauth.py
+++ b/tests/test_fedauth.py
@@ -1,0 +1,69 @@
+import unittest
+import sys
+import os
+
+# Add src to python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+
+from unittest.mock import MagicMock, patch
+import struct
+from pytds.tds_base import _TdsLogin
+from pytds import tds_base, connect
+from pytds.tds_socket import _TdsSocket
+from pytds.tds_session import _TdsSession
+from pytds.fedauth import fedauth_packet
+
+class TestFedAuth(unittest.TestCase):
+    def setUp(self):
+        # Patch find_spec to return None for OpenSSL to avoid import errors
+        self.patcher = patch('importlib.util.find_spec', return_value=None)
+        self.patcher.start()
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    def test_fedauth_packet_generation(self):
+        """Verify the FEDAUTH feature extension packet structure"""
+        login = _TdsLogin()
+        login.access_token = "mock_token"
+        
+        # Manually construct packet using the library's function
+        packet = fedauth_packet(login, True)
+        
+        # Verify header (Feature ID 0x02 for FEDAUTH)
+        self.assertEqual(packet[0], tds_base.TDS_LOGIN_FEATURE_FEDAUTH)
+        
+        # Verify content contains the token (UTF-16LE)
+        encoded_token = "mock_token".encode("UTF-16LE")
+        self.assertIn(encoded_token, packet)
+
+    def test_connect_with_callable(self):
+        """Simulate connect flow with access_token_callable"""
+        login = _TdsLogin()
+        login.tds_version = tds_base.TDS74
+        login.access_token_callable = lambda: "mock_token"
+        login.access_token = login.access_token_callable()
+        self.assertEqual(login.access_token, "mock_token")
+
+    @patch('pytds._connect')
+    def test_connect_with_token(self, mock_connect):
+        """Verify connect accepts access_token parameter and sets it on login"""
+        token = "direct_access_token"
+        connect(dsn="localhost", access_token=token)
+        
+        # Check if _connect was called
+        self.assertTrue(mock_connect.called)
+        
+        # Check if the login object passed to _connect has the token set
+        # _connect args: login, host, port, ...
+        # args[0] is login object
+        call_args = mock_connect.call_args
+        if call_args.args:
+            login_obj = call_args.args[0]
+        else:
+            login_obj = call_args.kwargs['login']
+            
+        self.assertEqual(login_obj.access_token, token)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# feat: Add Azure SQL Token Auth support via `access_token` parameter

## Description
This PR adds direct support for Azure Active Directory (AAD) token-based authentication by introducing an `access_token` parameter to the `connect()` function.

Previously, `access_token` support existed internally via `access_token_callable` or manual `_TdsLogin` manipulation, but it was not exposed as a first-class citizen in the public API. This change simplifies the workflow for modern cloud applications using Managed Identities or Service Principals.

## Changes
- **`src/pytds/__init__.py`**: Added `access_token` parameter to `connect()`. Added validation to ensure it is mutually exclusive with `user`/`password` and `access_token_callable`.
- **`tests/test_fedauth.py`**: Added unit tests to verify:
    - Correct construction of the `FEDAUTH` (Feature Ext) packet.
    - Correct propagation of the `access_token` from `connect()` to the login context.

## Example Usage
```python
import pytds

token = "eyJ0eXAiOiJKV1QiLCJhbG..." # Your AAD Access Token

conn = pytds.connect(
    dsn="my-sql-server.database.windows.net",
    database="my_db",
    access_token=token
)
```

## Related Issue
Fixes #135
