### PR TITLE
Fix hostname verification stripping uppercase letters from DNS names

### DIFF
--- a/src/pytds/tls.py
+++ b/src/pytds/tls.py
@@ -95,7 +95,7 @@ def verify_cb(conn, cert, err_num, err_depth, ret_code: int) -> bool:
 
 def is_san_matching(san: str, host_name: str) -> bool:
     for item in san.split(','):
-        dnsentry = item.strip().lstrip('DNS:').strip()
+        dnsentry = item.strip().removeprefix('DNS:').strip()
         # SANs are usually have form like: DNS:hostname
         if dnsentry == host_name:
             return True

--- a/tests/tls_san_test.py
+++ b/tests/tls_san_test.py
@@ -15,3 +15,6 @@ def test_san():
     # test parsing multiple SANs
     assert is_san_matching("DNS:westus2-a.control.database.windows.net,DNS:*.database.windows.net", "my-sql-server.database.windows.net")
     assert is_san_matching("DNS:westus2-a.control.database.windows.net, DNS:*.database.windows.net", "my-sql-server.database.windows.net")
+    # test that DNS: prefix removal doesn't strip uppercase letters from hostname
+    assert is_san_matching("DNS:DNSSERVER.example.com", "DNSSERVER.example.com")
+    assert is_san_matching("DNS:SQL-DNS-Node.database.windows.net", "SQL-DNS-Node.database.windows.net")


### PR DESCRIPTION
  Replace lstrip('DNS:') with removeprefix('DNS:') in SAN matching.
  lstrip strips any characters from the given set, so hostnames starting
  with D, N, or S (e.g. DNSSERVER.example.com) would be incorrectly
  truncated. removeprefix correctly removes only the exact 'DNS:' prefix.