### PR TITLE
Allow connecting to servers with different hostnames

### DIFF
--- a/src/pytds/__init__.py
+++ b/src/pytds/__init__.py
@@ -134,13 +134,14 @@ def connect(
     server: str | None = None,
     cafile: str | None = None,
     sock: socket.socket | None = None,
-    validate_host: bool = True,
+    validate_host: bool | str = True,
     enc_login_only: bool = False,
     disable_connect_retry: bool = False,
     pooling: bool = False,
     use_sso: bool = False,
     isolation_level: int = 0,
     access_token_callable: Callable[[], str] | None = None,
+    server_name: str | None = None,
 ):
     """
     Opens connection to the database
@@ -362,6 +363,7 @@ def connect(
         return _connect(
             login=login,
             host=host,
+            server_name=server_name,
             port=port,
             instance=instance,
             timeout=attempt_timeout,
@@ -411,6 +413,7 @@ def connect(
 def _connect(
     login: tds_base._TdsLogin,
     host: str,
+    server_name: str | None,
     port: int | None,
     instance: str,
     timeout: float,
@@ -426,7 +429,7 @@ def _connect(
     """
     Establish physical connection and login.
     """
-    login.server_name = host
+    login.server_name = server_name or host
     login.instance_name = instance
     resolved_port = instance_browser_client.resolve_instance_port(
         server=host, port=port, instance=instance, timeout=timeout
@@ -465,11 +468,11 @@ def _connect(
             ###  Change SPN once route exists
 
             if isinstance(login.auth, pytds_login.SspiAuth):
-                route_spn = f"MSSQLSvc@{host}:{port}"
+                route_spn = f"MSSQLSvc@{login.server_name}:{port}"
                 login.auth = pytds_login.SspiAuth(
                     user_name=login.user_name,
                     password=login.password,
-                    server_name=host,
+                    server_name=login.server_name,
                     port=port,
                     spn=route_spn,
                 )
@@ -477,6 +480,7 @@ def _connect(
             return _connect(
                 login=login,
                 host=route["server"],
+                server_name=server_name,
                 port=route["port"],
                 instance=instance,
                 timeout=timeout,

--- a/src/pytds/tls.py
+++ b/src/pytds/tls.py
@@ -162,7 +162,9 @@ def establish_channel(tds_sock: _TdsSession) -> None:
     if not tls_ctx:
         raise Exception("login.tls_ctx is not set unexpectedly")
 
-    bhost = login.server_name.encode("ascii")
+    bhost = (login.validate_host.encode("ascii")
+             if (login.validate_host and isinstance(login.validate_host, str))
+             else login.server_name.encode("ascii"))
     tls_ctx = login.tls_ctx
     if tls_ctx is None:
         raise tds_base.Error("TLS context is not set")


### PR DESCRIPTION
This adds a `server_name` param to the `connect()` method to allow specifying the host name of the database server when it differs from the server you need to connect to.

For example, it may be necessary to connect to a proxy in order to route around a firewall. In this scenario, specify the host name of the proxy as the `dsn` and the name of the server that will eventually be connected to as `server_name` (which will be used during login and for SNI/TLS validation by default). 

I initially thought it would be better to leave the `dsn` intact and add a `connect_to` (or similar) param instead, but this approach seems to work better with the `failover_partner` and `load_balancer` (as they can specify other proxies) and had  a smaller impact to other code.

I'm not sure if this approach works properly with SSPI auth or handles connection routing properly as I don't have the means to test those.

I also modified the `validate_host` param to `connect()` to allow specifying a string. In the case of a string value, it will be used for SNI and compared to the certificate in place of the `dsn` (useful in the event of a proxy doing TLS termination or the server's certificate otherwise not matching its DNS while still allowing certificate validation).

(I needed this myself and don't mind if you don't want to land this, I just thought I'd give back in case it helps others with a similar need.)