### PR TITLE
Fix varbinary(max) bulk copy (copy_to): use PLP_UNKNOWN for the length

### DIFF
--- a/src/pytds/tds_types.py
+++ b/src/pytds/tds_types.py
@@ -1187,7 +1187,13 @@ class VarBinarySerializerMax(VarBinarySerializer):
         if val is None:
             w.put_uint8(tds_base.PLP_NULL)
         else:
-            w.put_uint8(len(val))
+            # PLP total length must be PLP_UNKNOWN (streaming), like the NVarChar/
+            # VarChar Max serializers. Sending the known length here makes SQL
+            # Server's bulk path read the value (incl. the inner chunk-length
+            # prefix) as raw bytes, corrupting it -- which surfaces as a
+            # "premature end-of-message" desync, or a UDT deserialize running off
+            # the end when bulk-copying varbinary(max) into a CLR UDT column.
+            w.put_uint8(tds_base.PLP_UNKNOWN)
             if val:
                 w.put_uint(len(val))
                 w.write(val)

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -769,6 +769,38 @@ class TestMessages(unittest.TestCase):
             b"\xfe\xff\xff\xff\xff\xff\xff\xff\x08\x00\x00\x00t\x00e\x00s\x00t\x00\x00\x00\x00\x00",
         )
 
+    def test_varbinary_max_serializer(self):
+        # Regression: VarBinarySerializerMax.write must send PLP_UNKNOWN as the
+        # total length (like the NVarChar/VarChar Max serializers above), not the
+        # known length. Sending the known length makes SQL Server's bulk path read
+        # the value -- including the inner chunk-length prefix -- as raw bytes,
+        # corrupting varbinary(max) bulk inserts (and varbinary(max) -> CLR UDT).
+        sock = _FakeSock(b"")
+        tds = _TdsSocket(sock=sock, login=_TdsLogin())
+        tds.tds_version = TDS72
+        w = tds._main_session._writer
+
+        t = VarBinarySerializerMax()
+
+        t.write_info(w)
+        self.assertEqual(w._buf[: w._pos], b"\xff\xff")  # PLP_MARKER -> varbinary(max)
+
+        w._pos = 0
+        t.write(w, b"test")
+        self.assertEqual(
+            w._buf[: w._pos],
+            b"\xfe\xff\xff\xff\xff\xff\xff\xff"  # total length = PLP_UNKNOWN (streaming)
+            b"\x04\x00\x00\x00"  # chunk length = 4
+            b"test"  # chunk data
+            b"\x00\x00\x00\x00",  # PLP terminator (zero-length chunk)
+        )
+
+        w._pos = 0
+        t.write(w, None)
+        self.assertEqual(
+            w._buf[: w._pos], b"\xff\xff\xff\xff\xff\xff\xff\xff"  # PLP_NULL
+        )
+
 
 def infer_tds_serializer(
     value, serializer_factory, collation=None, bytes_to_unicode=True, allow_tz=True


### PR DESCRIPTION
Fixes #197.

`VarBinarySerializerMax.write` wrote the PLP total-length field as the value's known length, whereas the sibling MAX serializers (`NVarCharMaxSerializer`, `VarCharMaxSerializer`) write `PLP_UNKNOWN`. On the `copy_to` / `INSERT BULK` path, SQL Server then reads that many bytes raw — including the inner chunk-length prefix — so the value is corrupted, and larger values fail outright with "premature end-of-message".

This also broke bulk-loading **CLR UDT** columns: SQL Server converts `varbinary(max)` → a UDT on insert (works via a normal `INSERT`/`SqlBulkCopy`), but via `copy_to` the corrupted bytes made the UDT deserializer throw
`System.IO.EndOfStreamException`. With this fix, `varbinary(max)` round-trips through `copy_to`, and UDT columns can be bulk-loaded by declaring the column `VarBinaryMaxType` and sending the serialized bytes.

The change is a one-liner bringing `VarBinarySerializerMax` in line with the other MAX serializers. Added a byte-level regression test mirroring the existing `NVarCharMax` assertion in `test_types` (it fails on the old length, passes on `PLP_UNKNOWN`); sized `varbinary(N)` is unaffected.
