### PR TITLE
Allow connecting to a proxy with a different logical server name and TLS hostname

### DIFF
--- a/src/pytds/__init__.py
+++ b/src/pytds/__init__.py
@@ -141,6 +141,8 @@ def connect(
     use_sso: bool = False,
     isolation_level: int = 0,
     access_token_callable: Callable[[], str] | None = None,
+    logical_server_name: str | None = None,
+    tls_hostname: str | None = None,
 ):
     """
     Opens connection to the database
@@ -200,6 +202,14 @@ def connect(
              Cannot be used together with auth parameter.
     :keyword access_token_callable: Callable that returns a Federated Authentication Token
     :type access_token_callable: Callable[[], str]
+    :keyword logical_server_name: The server name to present during login and to use when
+      building the Kerberos/SSPI SPN, if it differs from the host being connected to
+      (e.g. when connecting through a proxy). Defaults to the connection host.
+    :type logical_server_name: str
+    :keyword tls_hostname: The host name to use for TLS SNI and certificate validation, if it
+      differs from ``logical_server_name`` (e.g. when a proxy performs TLS termination under a
+      different name). Defaults to ``logical_server_name``.
+    :type tls_hostname: str
     :returns: An instance of :class:`Connection`
     """
     if use_sso and auth:
@@ -295,7 +305,7 @@ def connect(
         parsed_servers.append((host, instance_port, instance))
 
     if use_sso:
-        spn = f"MSSQLSvc@{parsed_servers[0][0]}:{parsed_servers[0][1]}"
+        spn = f"MSSQLSvc@{logical_server_name or parsed_servers[0][0]}:{parsed_servers[0][1]}"
         try:
             login.auth = pytds_login.SspiAuth(spn=spn)
         except ImportError:
@@ -362,6 +372,8 @@ def connect(
         return _connect(
             login=login,
             host=host,
+            logical_server_name=logical_server_name,
+            tls_hostname=tls_hostname,
             port=port,
             instance=instance,
             timeout=attempt_timeout,
@@ -411,6 +423,8 @@ def connect(
 def _connect(
     login: tds_base._TdsLogin,
     host: str,
+    logical_server_name: str | None,
+    tls_hostname: str | None,
     port: int | None,
     instance: str,
     timeout: float,
@@ -426,7 +440,8 @@ def _connect(
     """
     Establish physical connection and login.
     """
-    login.server_name = host
+    login.server_name = logical_server_name or host
+    login.tls_hostname = tls_hostname or login.server_name
     login.instance_name = instance
     resolved_port = instance_browser_client.resolve_instance_port(
         server=host, port=port, instance=instance, timeout=timeout
@@ -465,11 +480,11 @@ def _connect(
             ###  Change SPN once route exists
 
             if isinstance(login.auth, pytds_login.SspiAuth):
-                route_spn = f"MSSQLSvc@{host}:{port}"
+                route_spn = f"MSSQLSvc@{login.server_name}:{port}"
                 login.auth = pytds_login.SspiAuth(
                     user_name=login.user_name,
                     password=login.password,
-                    server_name=host,
+                    server_name=login.server_name,
                     port=port,
                     spn=route_spn,
                 )
@@ -477,6 +492,8 @@ def _connect(
             return _connect(
                 login=login,
                 host=route["server"],
+                logical_server_name=logical_server_name,
+                tls_hostname=tls_hostname,
                 port=route["port"],
                 instance=instance,
                 timeout=timeout,

--- a/src/pytds/tds_base.py
+++ b/src/pytds/tds_base.py
@@ -959,6 +959,7 @@ class _TdsLogin:
         self.client_host_name = ""
         self.library = ""
         self.server_name = ""
+        self.tls_hostname = ""
         self.instance_name = ""
         self.user_name = ""
         self.password = ""

--- a/src/pytds/tls.py
+++ b/src/pytds/tls.py
@@ -162,7 +162,7 @@ def establish_channel(tds_sock: _TdsSession) -> None:
     if not tls_ctx:
         raise Exception("login.tls_ctx is not set unexpectedly")
 
-    bhost = login.server_name.encode("ascii")
+    bhost = login.tls_hostname.encode("ascii")
     tls_ctx = login.tls_ctx
     if tls_ctx is None:
         raise tds_base.Error("TLS context is not set")
@@ -211,7 +211,7 @@ def establish_channel(tds_sock: _TdsSession) -> None:
                 if not validate_host(cert=conn.get_peer_certificate(), name=bhost):
                     raise tds_base.Error(
                         "Certificate does not match host name '{}'".format(
-                            login.server_name
+                            login.tls_hostname
                         )
                     )
             enc_sock = EncryptedSocket(transport=tds_sock.conn.sock, tls_conn=conn)

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -1711,6 +1711,149 @@ def test_cert_with_san(test_ca, server_key, address, root_ca_path):
             pass
 
 
+def test_logical_server_name_defaults_to_host(address):
+    with SimpleServer(address=address):
+        with pytds.connect(
+            dsn=address[0],
+            port=address[1],
+            user="sa",
+            password="password",
+            disable_connect_retry=True,
+            autocommit=True,
+        ) as con:
+            login = con._tds_socket._login
+            assert login.server_name == address[0]
+            assert login.tls_hostname == address[0]
+
+
+def test_logical_server_name_override(address):
+    with SimpleServer(address=address):
+        with pytds.connect(
+            dsn=address[0],
+            port=address[1],
+            user="sa",
+            password="password",
+            disable_connect_retry=True,
+            autocommit=True,
+            logical_server_name="logical.example.com",
+        ) as con:
+            login = con._tds_socket._login
+            # server_name (used for LOGIN7/SPN) is overridden
+            assert login.server_name == "logical.example.com"
+            # tls_hostname defaults to the (overridden) server_name
+            assert login.tls_hostname == "logical.example.com"
+
+
+def test_tls_hostname_defaults_to_logical_server_name(
+    test_ca, server_key, address, root_ca_path
+):
+    from cryptography import x509
+
+    builder = x509.CertificateBuilder()
+
+    # certificate issued for the logical server name, not for the dsn/address
+    cert = test_ca.sign(
+        name="logicalname",
+        cb=builder.subject_name(
+            x509.Name([x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, "logicalname")])
+        )
+        .not_valid_before(datetime.datetime.utcnow())
+        .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=1))
+        .serial_number(x509.random_serial_number())
+        .public_key(server_key.public_key()),
+    )
+
+    with SimpleServer(
+        address=address, enc=PreLoginEnc.ENCRYPT_ON, cert=cert, key=server_key
+    ):
+        with pytds.connect(
+            dsn=address[0],
+            port=address[1],
+            user="sa",
+            password="password",
+            disable_connect_retry=True,
+            autocommit=True,
+            cafile=root_ca_path,
+            logical_server_name="logicalname",
+        ) as con:
+            login = con._tds_socket._login
+            assert login.tls_hostname == "logicalname"
+
+
+def test_tls_hostname_override_takes_precedence(
+    test_ca, server_key, address, root_ca_path
+):
+    from cryptography import x509
+
+    builder = x509.CertificateBuilder()
+
+    # certificate issued for the tls_hostname, not for logical_server_name or dsn
+    cert = test_ca.sign(
+        name="certname",
+        cb=builder.subject_name(
+            x509.Name([x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, "certname")])
+        )
+        .not_valid_before(datetime.datetime.utcnow())
+        .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=1))
+        .serial_number(x509.random_serial_number())
+        .public_key(server_key.public_key()),
+    )
+
+    with SimpleServer(
+        address=address, enc=PreLoginEnc.ENCRYPT_ON, cert=cert, key=server_key
+    ):
+        with pytds.connect(
+            dsn=address[0],
+            port=address[1],
+            user="sa",
+            password="password",
+            disable_connect_retry=True,
+            autocommit=True,
+            cafile=root_ca_path,
+            logical_server_name="logical.example.com",
+            tls_hostname="certname",
+        ) as con:
+            login = con._tds_socket._login
+            # server_name (LOGIN7/SPN) keeps the logical override
+            assert login.server_name == "logical.example.com"
+            # tls_hostname overrides validation independently of server_name
+            assert login.tls_hostname == "certname"
+
+
+def test_tls_hostname_mismatch_fails(test_ca, server_key, address, root_ca_path):
+    from cryptography import x509
+
+    builder = x509.CertificateBuilder()
+
+    cert = test_ca.sign(
+        name="certname",
+        cb=builder.subject_name(
+            x509.Name([x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, "certname")])
+        )
+        .not_valid_before(datetime.datetime.utcnow())
+        .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=1))
+        .serial_number(x509.random_serial_number())
+        .public_key(server_key.public_key()),
+    )
+
+    with SimpleServer(
+        address=address, enc=PreLoginEnc.ENCRYPT_OFF, cert=cert, key=server_key
+    ):
+        with pytest.raises(pytds.Error) as excinfo:
+            pytds.connect(
+                dsn=address[0],
+                port=address[1],
+                user="sa",
+                password="password",
+                disable_connect_retry=True,
+                cafile=root_ca_path,
+                tls_hostname="wrong.example.com",
+            )
+        assert "Certificate does not match host name 'wrong.example.com'" in str(
+            excinfo.value
+        )
+
+
 @pytest.mark.skipif(
     not utils.hashlib_supports_md4(),
     reason="Current python version does not support MD4 which is needed for NTLM"


### PR DESCRIPTION
## Summary
- Adds two new optional `connect()` parameters: `logical_server_name` and `tls_hostname`, for the case where the TCP connection target (`dsn`) differs from the server's real identity (e.g. connecting through a proxy).
- `logical_server_name` overrides `login.server_name`, used for the LOGIN7 packet's server-name field and the Kerberos/SSPI SPN. Defaults to the connection host.
- `tls_hostname` overrides the TLS SNI hostname and certificate-validation name independently. Defaults to `logical_server_name`.
- `validate_host` stays a plain `bool`.

This covers the same proxy use case as #196 without overloading `validate_host` into `bool | str`, which conflated "should we validate" with "what name to validate against" and left SNI implicitly coupled to whichever value was passed. Discussed in #196.

## Test plan
- [x] `pytest tests/unit_test.py` — 41 passed, 1 skipped
- [x] New tests cover: default cascade (`dsn` → `server_name` → `tls_hostname`), `logical_server_name` override, `tls_hostname` defaulting to `logical_server_name`, `tls_hostname` overriding independently of `logical_server_name`, and certificate-mismatch failure with the overridden name

🤖 Generated with [Claude Code](https://claude.com/claude-code)