### PR TITLE
Cap cryptography <49.0.0 on the 32-bit AppVeyor leg only

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,9 @@ environment:
   matrix:
     - PYTHON: "C:\\Python310"
       SQLINSTANCE: SQL2017
+      # cryptography dropped 32-bit Windows wheels in 49.0.0; cap it here only
+      # so 64-bit legs keep getting the latest release. See win32_constraints.txt
+      PIP_CONSTRAINT: win32_constraints.txt
     - PYTHON: "C:\\Python310-x64"
       SQLINSTANCE: SQL2017
     - PYTHON: "C:\\Python310-x64"

--- a/win32_constraints.txt
+++ b/win32_constraints.txt
@@ -1,0 +1,6 @@
+# cryptography removed 32-bit Windows wheel support in 49.0.0
+# (deprecated in 47.0.0, removed in 49.0.0 - see
+# https://cryptography.io/en/latest/changelog/). Applied only to the
+# 32-bit AppVeyor leg via PIP_CONSTRAINT so 64-bit legs still get the
+# latest cryptography release.
+cryptography<49.0.0


### PR DESCRIPTION
## Summary
- The 32-bit `C:\Python310` AppVeyor leg has been failing to install `cryptography` (see PR #200's CI, and the same failure on #196/#198 before it).
- Root cause: `cryptography` deprecated 32-bit Windows wheels in 47.0.0 and removed them entirely in 49.0.0 ("Support for 32-bit Windows has been removed. Users should move to a 64-bit Python installation." — [changelog](https://cryptography.io/en/latest/changelog/)). `test_requirements.txt` pins `cryptography>=46.0.6` with no upper bound, so pip now resolves to 49.0.0+, which has no `win32` wheel, forcing a from-source build that fails without a Rust/OpenSSL toolchain on the AppVeyor image.
- Fix: add `win32_constraints.txt` (`cryptography<49.0.0`) and apply it only to the 32-bit matrix entry via `PIP_CONSTRAINT` in `appveyor.yml`. This pins that leg to 48.0.1 (the last version with a win32 wheel) while leaving 64-bit legs on the latest, unbounded `cryptography` release.
- This is a scoped fix rather than a global downgrade, since a blanket cap would mean 64-bit legs (and downstream users) miss future `cryptography` security fixes.

## Test plan
- [x] `pip install --dry-run -c win32_constraints.txt "cryptography>=46.0.6"` resolves to `cryptography-48.0.1` (confirmed to publish a `win32` wheel on PyPI), not source-only 49.x
- [ ] AppVeyor CI on this PR (32-bit leg should go green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)