### PR TITLE
Add live bulk-insert regression test for VARBINARY(MAX)

### DIFF
--- a/tests/connected_test.py
+++ b/tests/connected_test.py
@@ -323,7 +323,10 @@ def test_empty_query(cursor):
         (pytds.tds_types.VariantType(), [None]),
         # (pytds.tds_types.VariantType(), [100]),
         # (pytds.tds_types.ImageType(), [None]),
-        (pytds.tds_types.VarBinaryMaxType(), [None]),
+        (
+            pytds.tds_types.VarBinaryMaxType(),
+            [b"x" * 10000, b"foo", b"", None, b"bar"],
+        ),
         # (pytds.tds_types.NTextType(), [None]),
         # (pytds.tds_types.TextType(), [None]),
         # (pytds.tds_types.ImageType(), [b'']),


### PR DESCRIPTION
## Summary
- #198 (merged) already fixed the underlying bug: `VarBinarySerializerMax.write` now sends `PLP_UNKNOWN` for the PLP total-length field instead of the actual byte length, fixing bulk-insert of non-null `VARBINARY(MAX)` data.
- #198 added a byte-level unit test (`test_varbinary_max_serializer` in `tests/unit_test.py`) asserting the exact wire bytes, but the existing live-DB `test_bulk_insert_type` parametrization for `VarBinaryMaxType` in `tests/connected_test.py` still only exercised `[None]`.
- This PR closes that remaining gap: it extends the `VarBinaryMaxType` case with real byte payloads, so there's an end-to-end regression test that actually runs `INSERT BULK` against a live SQL Server, matching the coverage already given to the sibling `VarCharMaxType`/`NVarCharMaxType` cases.

Originally opened as a duplicate fix of #132/#198 before I saw #198 land; rebased onto master after #198 merged, so the only remaining diff is the test.

## Test plan
- [x] Confirmed the new `VarBinaryMaxType` case in `test_bulk_insert_type` passes against master (post-#198 fix)
- [x] Ran full `connected_test.py` + `unit_test.py` + `params_tests.py` against a live SQL Server: all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)