### PR TITLE
Make SAN DNS name matching case-insensitive

### DIFF
--- a/src/pytds/tls.py
+++ b/src/pytds/tls.py
@@ -94,8 +94,9 @@ def verify_cb(conn, cert, err_num, err_depth, ret_code: int) -> bool:
 
 
 def is_san_matching(san: str, host_name: str) -> bool:
+    host_name = host_name.lower()
     for item in san.split(','):
-        dnsentry = item.strip().removeprefix('DNS:').strip()
+        dnsentry = item.strip().removeprefix('DNS:').strip().lower()
         # SANs are usually have form like: DNS:hostname
         if dnsentry == host_name:
             return True

--- a/tests/tls_san_test.py
+++ b/tests/tls_san_test.py
@@ -18,3 +18,9 @@ def test_san():
     # test that DNS: prefix removal doesn't strip uppercase letters from hostname
     assert is_san_matching("DNS:DNSSERVER.example.com", "DNSSERVER.example.com")
     assert is_san_matching("DNS:SQL-DNS-Node.database.windows.net", "SQL-DNS-Node.database.windows.net")
+    # test that SAN matching is case insensitive, DNS names are not case sensitive
+    assert is_san_matching("DATABASE.COM", "database.com")
+    assert is_san_matching("database.com", "DATABASE.COM")
+    assert is_san_matching("DaTaBaSe.CoM", "dAtAbAsE.cOm")
+    assert is_san_matching("DNS:*.Database.Windows.Net", "my-sql-server.database.windows.net")
+    assert is_san_matching("DNS:*.database.windows.net", "my-sql-server.DATABASE.WINDOWS.NET")


### PR DESCRIPTION
## Summary
- DNS names are not case sensitive, so certificate SAN matching in `is_san_matching()` should not require an exact case match against the hostname
- Fixes the underlying issue reported in #165, but implements the case-folding inside `is_san_matching()` itself (including the wildcard branch) rather than upper-casing at the call site in `validate_host()`

## Test plan
- [x] Added test cases in `tests/tls_san_test.py` covering exact-match and wildcard SAN entries with mismatched case
- [x] Verified the new tests fail against the pre-fix code and pass with the fix
- [x] `pytest tests/tls_san_test.py -v` passes

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)